### PR TITLE
Don't crash setup on utf-8 character codes in ReadMe.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 with open("requirements.txt", "r") as fh:


### PR DESCRIPTION
When I run the setup.py, the installation crashes due to the ReadMe file having UTF-8 character codes.