### PR TITLE
Fix to install on windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 with open("README.md", "r", encoding="UTF-8") as fh:
     long_description = fh.read()
 
-with open("requirements.txt", "r") as fh:
+with open("requirements.txt", "r", encoding="UTF-8") as fh:
     require = fh.readlines()
 require = [x.strip() for x in require]
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="UTF-8") as fh:
     long_description = fh.read()
 
 with open("requirements.txt", "r") as fh:


### PR DESCRIPTION
## Description
`pip` has occurred an error on Windows when I tried to install this package.

```text
PS D:\Documents\VisualStudioCode\django-survey> pip3 install pySankeyBeta
Collecting pySankeyBeta
  Using cached https://files.pythonhosted.org/packages/d3/5d/dc33ef5c130f4b45ac362d85ec2a5bb3d2aaea32fc7e159233b96a8c6724/pySankeyBeta-1.0.4.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\username\AppData\Local\Temp\pip-install-chhyfjal\pySankeyBeta\setup.py", line 4, in <module>
        long_description = fh.read()
    UnicodeDecodeError: 'cp932' codec can't decode byte 0x97 in position 1819: illegal multibyte sequence

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in C:\Users\username\AppData\Local\Temp\pip-install-chhyfjal\pySankeyBeta\
```

This PR adds `encoding="UTF-8"` in open() function.